### PR TITLE
Fix Wrong Content Type

### DIFF
--- a/Web/templates/_js/amxbans.js.php
+++ b/Web/templates/_js/amxbans.js.php
@@ -1,4 +1,5 @@
 <?php require_once("../../include/init_session.php"); if(@$_SESSION["loggedin"]) { ?>
+<?php header('Content-Type: application/javascript'); ?>
 function LiveBanCopyVars (name,steamid,ip,userid) {
 	document.getElementById('player_name').value = name;
 	document.getElementById('player_uid').value = userid;


### PR DESCRIPTION
Sets `Content-Type: application/javascript` for the file *amxbans.js.php*.
This fixes the admin area page being partially broken due to the file getting rejected by browsers if `X-Content-Type-Options: nosniff` is set.